### PR TITLE
tweak the existing API for memory safe data sharing between `loop` and cloud

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
-name = "particle-hal"
+name = "photon-hal"
 version = "0.1.0"
 
 [dependencies]
+photon-core = { git = "https://github.com/japaric/photon-core" }
+static-ref = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# `particle-hal`
+# `photon-hal`
 
-> [WIP] Low level bindings to the Particle HAL (Hardware Abstraction Layer)
+> [WIP] Low level bindings to the Particle photon HAL (Hardware Abstraction
+> Layer)
 
 Firmware version: v0.6.2
 
-# API Documentation
+# API documentation
 
-Run `cargo doc --open`.
+Run the command:
+
+```
+$ cargo doc --open
+```
+
 
 # License
 

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -1,10 +1,17 @@
-use core::ptr;
+use core::cell::Cell;
+use core::{mem, ptr};
+
+use photon_core::Cloud;
+use static_ref::Ref;
 
 use {String, ll};
 
+/// Registers a new cloud function with the given `name`
+///
+/// **NOTE** Only up to 15 cloud functions can be registered
 pub fn function(
     name: &str,
-    f: extern "C" fn(&String) -> i32,
+    f: extern "C" fn(&String, Cloud) -> i32,
 ) -> Result<(), ()> {
     // the max length of the variable name is 12 characters
     if name.len() > 12 {
@@ -15,14 +22,23 @@ pub fn function(
     let mut buffer = [0; 13];
     buffer[..name.len()].copy_from_slice(name.as_bytes());
 
-    if unsafe { ll::spark_function(buffer.as_ptr(), f, ptr::null_mut()) } {
+    if unsafe {
+        ll::spark_function(buffer.as_ptr(), mem::transmute(f), ptr::null_mut())
+    }
+    {
         Ok(())
     } else {
         Err(())
     }
 }
 
-pub fn variable(name: &str, variable: &'static i32) -> Result<(), ()> {
+/// Registers a new cloud variable with the given `name`
+///
+/// **NOTE** Only up to 20 cloud variables can be registered
+pub fn variable<V>(name: &str, variable: V) -> Result<(), ()>
+where
+    V: IntRef,
+{
     // the max length of the variable name is 12 characters
     if name.len() > 12 {
         return Err(());
@@ -35,7 +51,7 @@ pub fn variable(name: &str, variable: &'static i32) -> Result<(), ()> {
     if unsafe {
         ll::spark_variable(
             buffer.as_ptr(),
-            variable as *const _ as *const _,
+            variable.as_ptr() as *const _,
             ll::Spark_Data_TypeDef::CLOUD_VAR_INT,
             ptr::null_mut(),
         )
@@ -44,5 +60,22 @@ pub fn variable(name: &str, variable: &'static i32) -> Result<(), ()> {
         Ok(())
     } else {
         Err(())
+    }
+}
+
+/// Implementation detail. Do not implement this trait.
+pub unsafe trait IntRef {
+    fn as_ptr(self) -> *const i32;
+}
+
+unsafe impl<'a> IntRef for Ref<'a, i32> {
+    fn as_ptr(self) -> *const i32 {
+        &*self
+    }
+}
+
+unsafe impl<'a> IntRef for Ref<'a, Cell<i32>> {
+    fn as_ptr(self) -> *const i32 {
+        (*self).as_ptr()
     }
 }

--- a/src/ctypes.rs
+++ b/src/ctypes.rs
@@ -5,6 +5,7 @@ pub type c_int = i32;
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_uint = u32;
+pub type c_ulong = u32;
 pub type c_unsigned = u32;
 pub type int32_t = i32;
 pub type uint16_t = u16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 #![deny(warnings)]
 #![no_std]
 
+extern crate photon_core;
+extern crate static_ref;
+
 use core::{ops, slice};
 
 pub mod cloud;
@@ -137,10 +140,15 @@ pub fn device_id() -> String {
     unsafe { ll::spark_deviceID() }
 }
 
-pub fn sleep_ms(us: u32) {
-    unsafe { ll::HAL_Delay_Milliseconds(us) }
+/// Waits for `ms` milliseconds
+///
+/// **WARNING** WiFi won't be serviced during this delay. The `App.delay_ms`
+/// method should be preferred over this function.
+pub fn delay_ms(ms: u32) {
+    unsafe { ll::HAL_Delay_Milliseconds(ms) }
 }
 
-pub fn sleep_us(us: u32) {
+/// Waits for `us` microseconds
+pub fn delay_us(us: u32) {
     unsafe { ll::HAL_Delay_Microseconds(us) }
 }

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -1,7 +1,8 @@
 //! Low level bindings to the HAL
 
 use String;
-use ctypes::{c_char, c_int, c_unsigned, int32_t, uint16_t, uint32_t, uint8_t};
+use ctypes::{c_char, c_int, c_ulong, c_unsigned, int32_t, uint16_t, uint32_t,
+             uint8_t};
 
 pub type pin_t = u16;
 pub type p_user_function_int_str_t = extern "C" fn(&String) -> c_int;
@@ -69,16 +70,19 @@ extern "C" {
     pub fn USB_USART_Init(baud_rate: uint32_t);
     pub fn USB_USART_Send_Data(byte: uint8_t);
 
+    // system
+    pub fn system_delay_ms(ms: c_ulong, force_no_background_loop: bool);
+
     // system_cloud
     pub fn spark_function(
-        _: *const c_char,
-        _: p_user_function_int_str_t,
+        name: *const c_char,
+        f: p_user_function_int_str_t,
         _: *mut c_void,
     ) -> bool;
     pub fn spark_variable(
-        _: *const c_char,
-        _: *const c_void,
-        _: Spark_Data_TypeDef,
+        name: *const c_char,
+        var: *const c_void,
+        ty: Spark_Data_TypeDef,
         _: *mut spark_variable_t,
     ) -> bool;
     pub fn spark_deviceID() -> String;
@@ -503,7 +507,6 @@ extern "C" {
 // DYNALIB_FN(2, system, set_ymodem_serial_flash_update_handler, void(ymodem_serial_flash_update_handler))
 // DYNALIB_FN(3, system, system_firmwareUpdate, bool(Stream*, void*))
 // DYNALIB_FN(4, system, system_fileTransfer, bool(system_file_transfer_t*, void*))
-// DYNALIB_FN(5, system, system_delay_ms, void(unsigned long, bool))
 // DYNALIB_FN(6, system, system_sleep, void(Spark_Sleep_TypeDef, long, uint32_t, void*))
 // DYNALIB_FN(7, system, system_sleep_pin, void(uint16_t, uint16_t, long, uint32_t, void*))
 // DYNALIB_FN(8, system, system_subscribe_event, int(system_event_t, system_event_handler_t*, void*))


### PR DESCRIPTION
functions.

Also, rename this crate to photon-hal because it has not been tested on other
devices.