### PR TITLE
WIP: Add socket

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate static_ref;
 use core::{ops, slice};
 
 pub mod cloud;
+pub mod socket;
 pub mod ll;
 
 use cty::{c_char, c_uchar, c_uint};

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -7,6 +7,20 @@ pub type pin_t = u16;
 pub type p_user_function_int_str_t = extern "C" fn(&String) -> c_int;
 pub type system_tick_t = u32;
 
+pub type sock_handle_t = uint32_t;
+pub type sock_result_t = int32_t;
+pub type socklen_t = usize;
+pub type network_interface_t = uint32_t;
+
+pub const AF_INET: uint8_t = 2;
+pub const AF_INET6: uint8_t = 23;
+
+#[repr(C)]
+pub struct sockaddr_t {
+    pub sa_family: uint16_t,
+    pub sa_data: [uint8_t; 14],
+}
+
 #[repr(C)]
 pub struct spark_variable_t {
     pub size: uint16_t,
@@ -100,6 +114,36 @@ extern "C" {
     pub fn spark_deviceID() -> String;
     /// `micros`
     pub fn HAL_Timer_Get_Micro_Seconds() -> system_tick_t;
+
+    ///
+    pub fn socket_active_status(handle: sock_handle_t) -> uint8_t;
+
+    ///
+    pub fn socket_create(
+        family: uint8_t,
+        type_: uint8_t,
+        protocol: uint8_t,
+        port: uint16_t,
+        nif: network_interface_t,
+    ) -> sock_handle_t;
+
+    ///
+    pub fn socket_connect(handle: sock_handle_t, addr: *const sockaddr_t) -> int32_t;
+
+    // DYNALIB_FN(6, hal_socket, socket_send, sock_result_t(sock_handle_t, const void*, socklen_t))
+    ///
+    pub fn socket_send(handle: sock_handle_t, data: *const c_void, len: socklen_t) -> sock_result_t;
+
+    // DYNALIB_FN(7, hal_socket, socket_sendto, sock_result_t(sock_handle_t, const void*, socklen_t, uint32_t, sockaddr_t*, socklen_t))
+    ///
+    pub fn socket_sendto(handle: sock_handle_t, data: *const c_void, len: socklen_t, addr: *const sockaddr_t) -> sock_result_t;
+
+    // DYNALIB_FN(4, hal_socket, socket_receive, sock_result_t(sock_handle_t, void*, socklen_t, system_tick_t))
+    ///
+    pub fn socket_receive(handle: sock_handle_t, data: *const c_void, len: socklen_t, timeout: system_tick_t) -> sock_result_t;
+
+    ///
+    pub fn socket_close(handle: sock_handle_t) -> sock_result_t;
 }
 
 // TODO add bindings for all functions below, but be sure to know which

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,0 +1,48 @@
+use ll;
+
+pub struct TCPClient {
+    socket: ll::sock_handle_t,
+}
+
+impl TCPClient {
+    pub fn new() -> TCPClient {
+        let socket = unsafe {
+            ll::socket_create(ll::AF_INET, 1, 6, 1337, 0)
+        };
+        TCPClient {
+            socket: socket,
+        }
+    }
+
+    pub fn connect(&self, ip: [u8; 4], port: u16) -> Result<(), ()> {
+
+        let mut socket_addr = ll::sockaddr_t {
+            sa_family: ll::AF_INET as u16,
+            sa_data: [0; 14],
+        };
+
+        socket_addr.sa_data[0] = (port >> 8) as u8;
+        socket_addr.sa_data[1] = (port & 0xFF) as u8;
+
+        socket_addr.sa_data[2] = ip[0];
+        socket_addr.sa_data[3] = ip[1];
+        socket_addr.sa_data[4] = ip[2];
+        socket_addr.sa_data[5] = ip[3];
+
+        let connect_res = unsafe {
+            ll::socket_connect(self.socket, &socket_addr)
+        };
+
+        if connect_res == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn send(&self, data: &[u8]) {
+        let ptr = data.as_ptr();
+        let len = data.len();
+        unsafe { ll::socket_send(self.socket, ptr as *const ll::c_void, len); }
+    }
+}


### PR DESCRIPTION
This does not yet work, but is intended to fix #17.

As soon as I actually try to use the `socket_send` function from an executable (see https://github.com/rnestler/photon-quickstart/blob/socket_example/examples/socket.rs#L45) I get a linker error:
```
error: linking with `arm-none-eabi-g++` failed: exit code: 1
  |
  = note: "arm-none-eabi-g++" "-g3" "-gdwarf-2" "-Os" "-mcpu=cortex-m3" "-mthumb" "-ffunction-sections" "-fdata-sections" "-fno-builtin-malloc" "-fno-builtin-free" "-fno-builtin-realloc" "build/target/user-part/platform-6-m/src/user_module.o" "build/target/user-part/platform-6-m/src/module_info.o" "build/target/user-part/platform-6-m/src/user_export.o" "build/target/user-part/platform-6-m/src/newlib_stubs.o" "-Wl,--whole-archive" "hal/src/photon/lib/STM32F2xx_Peripheral_Libraries.a" "-Wl,--no-whole-archive" "-nostartfiles" "-Xlinker" "--gc-sections" "-L" "/home/roughl/.xargo/lib/rustlib/thumbv7m-none-eabi/lib" "/home/roughl/projects/rustfest_zurich_2017/impl_days/embedded/my-app/target/thumbv7m-none-eabi/debug/examples/socket-10cbf31a55c3ae7f.0.o" "-o" "/home/roughl/projects/rustfest_zurich_2017/impl_days/embedded/my-app/target/thumbv7m-none-eabi/debug/examples/socket-10cbf31a55c3ae7f" "-Wl,--gc-sections" "-nodefaultlibs" "-L" "/home/roughl/projects/rustfest_zurich_2017/impl_days/embedded/my-app/target/thumbv7m-none-eabi/debug/deps" "-L" "/home/roughl/projects/rustfest_zurich_2017/impl_days/embedded/my-app/target/debug/deps" "-L" "/home/roughl/projects/rustfest_zurich_2017/impl_days/embedded/my-app/target/thumbv7m-none-eabi/debug/build/photon-42b90ede45cf9044/out" "-L" "/home/roughl/projects/rustfest_zurich_2017/impl_days/embedded/my-app/target/thumbv7m-none-eabi/debug/build/photon-42b90ede45cf9044/out/photon/system-part1" "-L" "/home/roughl/.xargo/lib/rustlib/thumbv7m-none-eabi/lib" "-Wl,--whole-archive" "-lhal-dynalib" "-lservices-dynalib" "-lsystem-dynalib" "-lrt-dynalib" "-lwiring" "-lcommunication-dynalib" "-lplatform" "-lwiring_globals" "-Wl,--no-whole-archive" "-lc" "-lnosys" "-Tlinker.ld" "--specs=nano.specs" "-Wl,--defsym,USER_FIRMWARE_IMAGE_SIZE=0x20000" "-Wl,--defsym,USER_FIRMWARE_IMAGE_LOCATION=0x80A0000"
  = note: /usr/lib/gcc/arm-none-eabi/7.2.0/../../../../arm-none-eabi/bin/ld: Dynalib location not correct
          /usr/lib/gcc/arm-none-eabi/7.2.0/../../../../arm-none-eabi/bin/ld: Dynalib location not same as exported location
          collect2: error: ld returned 1 exit status
```